### PR TITLE
Fix the logic for validating current value by step

### DIFF
--- a/core/Number_Field.php
+++ b/core/Number_Field.php
@@ -82,14 +82,16 @@ class Number_Field extends Field {
 			$value = min( $value, $this->max );
 		}
 
-		if ( $this->step !== null ) {
-			$step_base = ( $this->min !== null ) ? $this->min : 0;
-			$is_valid_step_value = ( $value - $step_base ) % $this->step === 0;
-			if ( ! $is_valid_step_value ) {
-				$value = $step_base; // value is not valid - reset it to a base value
+		if ($this->step !== null) {
+			$min = ( $this->min !== null ) ? $this->min : 0;
+			// Base Formula "value = min + n * step" where "n" should be integer
+			$n = ( $value - $min ) / $this->step;
+			$is_valid_step = strpos(strval($n), '.') === false;
+			if (!$is_valid_step) {
+				$value = $min; // value is not valid - reset it to a base value
 			}
 		}
-
+		
 		$this->set_value( $value );
 	}
 


### PR DESCRIPTION
The previous code only works with integer steps, and does not account that modulo operator fails with 0.1 as the 2nd parameter.
The fmod also fails, by returning non-zero when 0 is expected.